### PR TITLE
fix: Handle months starting on a Sunday when weeks start with monday

### DIFF
--- a/src/components/monthCalendar/month-calendar.tsx
+++ b/src/components/monthCalendar/month-calendar.tsx
@@ -170,7 +170,13 @@ export class MonthCalendar {
 
     // Go back to the previous Monday, or Sunday if mode enabled.
     const weekStart = (this.startOnSundays ? 0 : 1);
-    const currentDay = now.getDay();
+    let currentDay = now.getDay();
+
+    // If month starts on Sunday we need to treat currentDay as the last day of the week.
+    if (currentDay === 0 && weekStart === 1) {
+      currentDay = 7;
+    }
+
     const distance = weekStart - currentDay;
 
     now.setDate(now.getDate() + distance);


### PR DESCRIPTION
Hi @danjohnson95 

Noticed a bug that when the month starts on a Sunday, and you've set weeks to show Monday as the first day.  It does not render the first day.

![Screenshot 2025-02-17 at 14 37 19](https://github.com/user-attachments/assets/2c95e51f-8fc1-47ae-a50a-d2ce7c69d6d7)

This fixes the issue.  I've tested it with weeks and months, both starting on Monday and Sunday.
